### PR TITLE
#27286 Adding maven profile to build the uber-jar with metadata.

### DIFF
--- a/.github/workflows/cli-build-artifacts.yml
+++ b/.github/workflows/cli-build-artifacts.yml
@@ -176,7 +176,7 @@ jobs:
         if: ${{ matrix.label == 'Linux' }}
         working-directory: ${{ github.workspace }}
         run: |
-          ./mvnw package -Dquarkus.package.type="uber-jar" -DskipTests=$SKIP_TESTS -pl :dotcms-cli
+          ./mvnw package -Puber-jar -DskipTests=$SKIP_TESTS -pl :dotcms-cli
 
       # Builds a native image of the CLI using GRAALVM (Linux/macOS)
       # Runs on a matrix for different operating systems

--- a/tools/dotcms-cli/cli/pom.xml
+++ b/tools/dotcms-cli/cli/pom.xml
@@ -321,6 +321,52 @@
                 <quarkus.native.additional-build-args>-H:ReflectionConfigurationFiles=reflection-config.json,-H:ResourceConfigurationFiles=resources-config.json</quarkus.native.additional-build-args>
             </properties>
         </profile>
+
+        <profile>
+            <id>uber-jar</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>${quarkus.platform.group-id}</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${quarkus.platform.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>generate-code</goal>
+                                    <goal>generate-code-tests</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <testcontainers.docker.image>${testcontainers.docker.image}</testcontainers.docker.image>
+                                    </systemProperties>
+                                    <manifestEntries>
+                                        <Implementation-URL>${project.url}</Implementation-URL>
+                                        <Java-Vendor>${java.vendor}</Java-Vendor>
+                                        <Java-Version>${java.version}</Java-Version>
+                                        <Os-Arch>${os.arch}</Os-Arch>
+                                        <Os-Name>${os.name}</Os-Name>
+                                        <Os-Version>${os.version}</Os-Version>
+                                        <Scm-Connection>${project.scm.connection}</Scm-Connection>
+                                        <Scm-Url>${project.scm.url}</Scm-Url>
+                                        <Scm-Revision>${buildNumber}</Scm-Revision>
+                                        <!--suppress UnresolvedMavenProperty-->
+                                        <Scm-Build>${scmBranch}</Scm-Build>
+                                        <Implementation-Build>${buildNumber}</Implementation-Build>
+                                        <Implementation-Timestamp>${timestamp}</Implementation-Timestamp>
+                                    </manifestEntries>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>uber-jar</quarkus.package.type>
+            </properties>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
### Proposed Changes
* Adding maven profile to build the uber-jar with metadata. Avoiding NPE when `./mvnw quarkus:dev` is run.

### Fixes
#27286 
