### PR TITLE
#27805 cli-npm-publish refactored to an action.

### DIFF
--- a/.github/actions/publish-npm-cli/action.yml
+++ b/.github/actions/publish-npm-cli/action.yml
@@ -1,0 +1,241 @@
+name: 'Package CLI project'
+description: 'Package the dotCMS CLI as an NPM project.'
+inputs:
+  ref:
+    description: 'Branch to build from'
+    required: false
+    default: 'master'
+  github-token:
+    description: 'GitHub Token'
+    required: true
+  npm-token:
+    description: 'NPM Token'
+    required: true
+  npm-package-name:
+    description: 'NPM package name'
+    required: false
+    default: 'dotcli'
+  npm-package-scope:
+    description: 'NPM package scope'
+    required: false
+    default: '@dotcms'
+  node-version:
+    description: 'Node.js version'
+    required: false
+    default: '19'
+  workflow-to-search:
+    description: 'Workflow to search for artifacts'
+    required: false
+    default: 'build-test-master.yml'
+  artifact-id:
+    description: 'Artifact id'
+    required: false
+    default: 'cli-artifacts-*'
+
+runs:
+  using: "composite"
+  steps:
+    - name: 'Checkout'
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: 'Set up Node.js'
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: 'Install Jinja2'
+      run: pip install jinja2-cli
+      shell: bash
+
+    - name: 'Download Build Artifact'
+      id: data-download
+      uses: dawidd6/action-download-artifact@v3.1.4
+      with:
+        github_token: ${{ inputs.github-token }}
+        workflow: ${{ inputs.workflow-to-search }}
+        #commit: ${{ github.sha }}
+        workflow_conclusion: success
+        search_artifacts: true
+        dry_run: true
+        name: ${{ inputs.artifact-id }}
+        name_is_regexp: true
+        path: .
+        if_no_artifact_found: warn
+
+    - name: 'Check if artifact exists'
+      id: check
+      run: |
+        build_artifact_exists=${{ steps.data-download.outputs.found_artifact }}
+        if [[ ${build_artifact_exists} == "true" ]]; then
+            run_id=`echo '${{ steps.data-download.outputs.artifacts }}' | jq -r '.[0].workflow_run.id'`
+            found_artifacts=true
+            echo "Artifact Run id: $run_id"
+        else
+           echo "No artifact found"
+           run_id="${{ github.run_id }}"
+           found_artifacts=false
+        fi
+        echo "run_id=$run_id" >> $GITHUB_OUTPUT
+        echo "found_artifacts=$found_artifacts" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: 'Download all build artifacts'
+      id: download-cli-artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: ${{ inputs.artifact-id }}
+        path: ${{ github.workspace }}/artifacts
+        github-token: ${{ inputs.github-token }} # token with actions:read permissions on target repo
+        merge-multiple: true
+        run-id: ${{ steps.check.outputs.run_id }}
+
+    - name: 'List CLI Artifacts'
+      run: |
+        echo "::group::CLI Artifacts"
+        echo "Artifacts"
+        ls -R ${{ github.workspace }}/artifacts
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'Extract run-id'
+      id: extract-metadata
+      run: |
+        echo "run-id=${{ github.run_id }}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: 'Extract package version'
+      id: project
+      run: |
+        echo "::group::Extract package version"
+        version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout -pl :dotcms-cli)
+        echo "::debug::PROJECT VERSION: $version"
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
+      shell: bash
+    # Determines the NPM package version and tag
+    # Distinguishes between snapshots and releases
+
+    - name: 'Dynamic configuration of NPM package Version and Tag'
+      id: npm-version-tag
+      run: |
+        echo "::group::NPM package Version and Tag"
+        MVN_PACKAGE_VERSION=$(echo ${{ steps.project.outputs.version }} | tr '[:lower:]' '[:upper:]')
+        PACKAGE_FULL_NAME=${{ inputs.npm-package-scope }}/${{ inputs.npm-package-name }}
+
+        # Check if the npm package exists
+        if ! npm view $PACKAGE_FULL_NAME &> /dev/null; then
+          echo "::error::The package $PACKAGE_FULL_NAME does not exist on npm."
+          exit 1
+        fi
+
+        # Check if the package is a snapshot
+        REGEX="([0-9]+\.[0-9]+\.[0-9]+)-SNAPSHOT"
+
+        if [[ $MVN_PACKAGE_VERSION =~ $REGEX ]]; then
+          echo "::debug::Snapshot version found."
+
+          NPM_PACKAGE_VERSION_TAG="rc"
+          MVN_BASE_VERSION="${BASH_REMATCH[1]}"
+
+          # Use regular expression to extract version components
+          if [[ $MVN_BASE_VERSION =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            MAJOR=$(echo "${BASH_REMATCH[1]}" | sed "s/\b0\+\([1-9]\)/\1/g")
+            MINOR=$(echo "${BASH_REMATCH[2]}" | sed "s/\b0\+\([1-9]\)/\1/g")
+            PATCH=$(echo "${BASH_REMATCH[3]}" | sed "s/\b0\+\([1-9]\)/\1/g")
+            VERSION_NPM_FORMAT="${MAJOR}.${MINOR}.${PATCH}"
+
+            echo "::debug::VERSION_NPM_FORMAT: ${VERSION_NPM_FORMAT}"
+          else
+            echo "::error::Invalid Maven version format: $MVN_BASE_VERSION"
+            exit 1
+          fi
+
+          echo "VERSION_NPM_FORMAT: ${VERSION_NPM_FORMAT}"
+          LAST_RC_VERSIONS=$(npm view $PACKAGE_FULL_NAME versions --json)
+          echo "LAST_RC_VERSIONS: ${LAST_RC_VERSIONS}"
+
+          LAST_RC_VERSION=$(npm view $PACKAGE_FULL_NAME versions --json | jq --arg filter $VERSION_NPM_FORMAT 'map(.| select(. | contains($filter)))' | jq -r 'map(select(test("-rc\\d+$"))) | max')
+
+          if [[ $LAST_RC_VERSION == "$VERSION_NPM_FORMAT"* ]]; then
+            NEXT_RC_VERSION=$(echo "$LAST_RC_VERSION" | awk -F '-rc' '{print $1 "-rc" $2 + 1}')
+            RC_SUFFIX=$(echo "$NEXT_RC_VERSION" | sed -n 's/.*-rc\([0-9]*\)/-rc\1/p')
+          else
+            RC_SUFFIX="-rc1"
+          fi;
+
+          NPM_PACKAGE_VERSION=${MVN_BASE_VERSION}${RC_SUFFIX}
+        else
+          echo "::debug::Release version found."
+          NPM_PACKAGE_VERSION_TAG="latest"
+          NPM_PACKAGE_VERSION=${MVN_PACKAGE_VERSION}
+        fi;
+        echo "::debug::NPM_PACKAGE_VERSION: $NPM_PACKAGE_VERSION"
+        echo "::debug::NPM_PACKAGE_VERSION_TAG: $NPM_PACKAGE_VERSION_TAG"
+
+        echo "npm-package-version=$NPM_PACKAGE_VERSION" >> $GITHUB_OUTPUT
+        echo "npm-package-version-tag=$NPM_PACKAGE_VERSION_TAG" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
+      shell: bash
+
+
+    # Sets up the NPM package
+    # Creates the bin folder with the binaries
+    # Adds the postinstall.js script
+    # Generates the package.json file with Jinja2
+
+    - name: 'NPM Package setup'
+      working-directory: ${{ github.workspace }}/tools/dotcms-cli/npm/
+      env:
+        NPM_PACKAGE_NAME: ${{ inputs.npm-package-name }}
+        NPM_PACKAGE_VERSION: ${{ steps.npm-version-tag.outputs.npm-package-version }}
+        MVN_PACKAGE_NAME: dotcms-cli
+        MVN_PACKAGE_VERSION: ${{ steps.project.outputs.version }}
+      run: |
+        echo "::group::NPM Package setup"
+        echo "Adding bin folder with all the binaries"
+        mkdir -p bin
+        find ${{ github.workspace }}/artifacts/cli/target/distributions/ -name "*.zip" -exec unzip -d bin {} \;
+
+        echo "Adding wrapper script"
+        mv src/postinstall.js.seed src/postinstall.js
+
+        echo "Adding README.md file"
+        cp ${{ github.workspace }}/tools/dotcms-cli/README.md .
+
+        echo "Adding package.json file"
+        jinja2 package.j2 -D packageName=${MVN_PACKAGE_NAME} -D npmPackageName=${NPM_PACKAGE_NAME} -D npmPackageVersion=${NPM_PACKAGE_VERSION} -D packageVersion=${MVN_PACKAGE_VERSION} --format json -o package.json
+        rm -f package.j2
+
+        cat package.json
+        cat src/postinstall.js
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'NPM Package tree'
+      run: ls -R ${{ github.workspace }}/tools/dotcms-cli/npm/
+      shell: bash
+
+    - name: 'Validate NPM package'
+      run: |
+        echo "::group::NPM package contents"
+        if [ ! -f ${{ github.workspace }}/npm/package.json ]; then
+          echo "::error::NPM package not found. Exiting..."
+          exit 1
+        else
+          echo "::notice::NPM package found. Proceeding..."
+          cat ${{ github.workspace }}/npm/package.json
+        fi
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'Publish to NPM registry'
+      working-directory: ${{ github.workspace }}/npm-package
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
+        NPM_PACKAGE_VERSION_TAG: ${{ steps.npm-version-tag.outputs.npm-package-version-tag }}
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+        npm publish --access public --tag ${NPM_PACKAGE_VERSION_TAG}
+      shell: bash

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -92,6 +92,13 @@ jobs:
           build-run-id: ${{ inputs.artifact-run-id }}
           commit-id: ${{ github.sha }}
 
+      - name: CLI Publish
+        if: inputs.publish-npm-package
+        uses: ./.github/actions/publish-npm-cli
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+
       # A Slack notification is sent using the 'action-slack-notify' action if the repository is 'dotcms/core'.
       - name: Slack Notification
         if: github.repository == 'dotcms/core'
@@ -105,14 +112,3 @@ jobs:
           SLACK_FOOTER: ""
           SLACK_ICON: https://avatars.githubusercontent.com/u/1005263?s=200&v=4
           SLACK_MESSAGE: "This automated script is happy to announce that a new docker image has been built for *master* with tags: [${{ steps.docker_build.outputs.tags }}] :docker:"
-
-  publish:
-    name: Publish
-    if: inputs.publish-npm-package
-    needs: [ deployment ]
-    uses: ./.github/workflows/cli-npm-build.yml
-    secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
-    permissions:
-      contents: read
-      packages: write


### PR DESCRIPTION
### Proposed Changes
* Refactor on `cli-build-npm`. `cli-npm-package` and `cli-npm-publish` are now combine only one action to be call it from `reusable-deployment`. This new approach fits in the cicd structure.

### Fixes
#27805
