### PR TITLE
#30871 replacing ubuntu latest and 20.04 by 22.04.

### DIFF
--- a/.github/workflows/cicd_comp_build-phase.yml
+++ b/.github/workflows/cicd_comp_build-phase.yml
@@ -50,7 +50,7 @@ jobs:
   # It provides a local Maven repo for subsequent steps.
   build-jdk11:
     name: "Initial Artifact Build"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: inputs.core-build == true
     permissions:
       contents: read

--- a/.github/workflows/cicd_comp_cli-native-build-phase.yml
+++ b/.github/workflows/cicd_comp_cli-native-build-phase.yml
@@ -56,7 +56,7 @@ jobs:
   # Job to determine the OS matrix for the build
   os-runners:
     name: 'Get OS matrix'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       runners: ${{ steps.set-os.outputs.runners }}
     steps:

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -63,7 +63,7 @@ on:
 
 jobs:
   deployment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Use of Docker environments to enable per-deployment environment secrets
     # This allows for different secrets to be used based on the deployment environment
     environment: ${{ inputs.environment }}

--- a/.github/workflows/cicd_comp_finalize-phase.yml
+++ b/.github/workflows/cicd_comp_finalize-phase.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   prepare-report-data:
     name: Prepare Report Data
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     outputs:
       aggregate_status: ${{ steps.prepare-workflow-data.outputs.aggregate_status }}
@@ -175,7 +175,7 @@ jobs:
     name: Final Status
     needs: prepare-report-data
     if: always()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Check the final status and fail the workflow if not successful
       - name: Check Final Status

--- a/.github/workflows/cicd_comp_initialize-phase.yml
+++ b/.github/workflows/cicd_comp_initialize-phase.yml
@@ -53,7 +53,7 @@ jobs:
   # This job is used as a required check to indicate that the workflow has started and is running
   initialize:
     name: Initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     steps:
       - run: echo 'GitHub context'
@@ -75,7 +75,7 @@ jobs:
   # This job checks for artifacts from previous builds and determines if they can be reused
   check-previous-build:
     name: Check Previous Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       artifact-run-id: ${{ steps.check.outputs.run_id }}
       found_artifacts: ${{ steps.check.outputs.found_artifacts }}
@@ -119,7 +119,7 @@ jobs:
     name: Check Changed Files
     needs: [ check-previous-build ]
     if: always() && !failure() && !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       build: ${{ steps.filter-rewrite.outputs.build }}
       backend: ${{ steps.filter-rewrite.outputs.backend }}

--- a/.github/workflows/cicd_comp_pr-notifier.yml
+++ b/.github/workflows/cicd_comp_pr-notifier.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   message-resolver:
     name: Resolve Message
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       message: ${{ steps.message-resolver.outputs.message }}
     steps:
@@ -69,7 +69,7 @@ jobs:
 
   pr-notifier:
     needs: [message-resolver, slack-channel-resolver]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cicd_comp_semgrep-phase.yml
+++ b/.github/workflows/cicd_comp_semgrep-phase.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   buildmavenDepTree:
     name: Semgrep Dep Tree
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only run on main branch or pull requests in the main repository
     if: |
       (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && github.repository == 'dotCMS/core'
@@ -55,7 +55,7 @@ jobs:
   semgrep:
     needs: buildmavenDepTree
     name: Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       NO_FAIL: ${{ vars.SEMGREP_NO_FAIL || 'false' }}

--- a/.github/workflows/cicd_comp_sonarqube-phase.yml
+++ b/.github/workflows/cicd_comp_sonarqube-phase.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   sonarqube:
     name: SonarQube Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only run on main branch or pull requests in the main repository
     if: |
       (github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && github.repository == 'dotCMS/core'

--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -60,7 +60,7 @@ jobs:
   # JVM Unit Tests
   linux-jvm-tests:
     name: JVM Unit Tests - JDK ${{matrix.java.name}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: inputs.jvm_unit_test || inputs.run-all-tests
     timeout-minutes: 240
     env:
@@ -82,7 +82,7 @@ jobs:
   # CLI Tests
   linux-cli-tests:
     name: CLI Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: inputs.cli || inputs.run-all-tests
     timeout-minutes: 240
     env:
@@ -106,7 +106,7 @@ jobs:
   # Frontend Tests
   linux-frontend-tests:
     name: Frontend Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: inputs.frontend || inputs.run-all-tests
     timeout-minutes: 240
     env:
@@ -128,7 +128,7 @@ jobs:
   # Integration Tests
   linux-integration-tests:
     name: JVM IT Tests ${{matrix.suites.name}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: inputs.integration || inputs.run-all-tests
     timeout-minutes: 240
     env:
@@ -162,7 +162,7 @@ jobs:
   # Postman Tests
   linux-postman-tests:
     name: Run Postman Tests - ${{matrix.collection_group}}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: inputs.postman || inputs.run-all-tests
     strategy:
       fail-fast: false
@@ -187,7 +187,7 @@ jobs:
   # Karate Tests
   karate-tests:
     name: Karate Tests - ${{ matrix.suites.name }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: inputs.karate || inputs.run-all-tests
     strategy:
       fail-fast: false
@@ -219,7 +219,7 @@ jobs:
   # E2E Tests
   linux-e2e-tests:
     name: E2E Tests ${{matrix.suites.name}}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: inputs.e2e || inputs.run-all-tests
     timeout-minutes: 240
     env:

--- a/.github/workflows/cicd_manual_build-docker-context.yml
+++ b/.github/workflows/cicd_manual_build-docker-context.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build_image:
     name: Build Docker Base Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout core
         uses: actions/checkout@v4

--- a/.github/workflows/cicd_manual_build-java-base.yml
+++ b/.github/workflows/cicd_manual_build-java-base.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build_image:
     name: Build Docker Base Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout core
         uses: actions/checkout@v4

--- a/.github/workflows/cicd_manual_publish-starter.yml
+++ b/.github/workflows/cicd_manual_publish-starter.yml
@@ -95,7 +95,7 @@ jobs:
           
   deploy-artifacts:
     needs: [ get-starter ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: starter
     outputs:
       filename: ${{ steps.deploy-artifacts.outputs.filename }}
@@ -197,7 +197,7 @@ jobs:
        
   send-notification:
     needs: [ deploy-artifacts ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.event.inputs.dry-run == 'false'
     steps:
 

--- a/.github/workflows/cicd_post-workflow-reporting.yml
+++ b/.github/workflows/cicd_post-workflow-reporting.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Log GitHub context for debugging
       - name: Log GitHub context

--- a/.github/workflows/cicd_release-cli.yml
+++ b/.github/workflows/cicd_release-cli.yml
@@ -59,7 +59,7 @@ jobs:
   precheck:
     if: ${{ ( github.event_name == 'release' && !contains(github.event.release.tag_name, 'LTS')) || github.event_name == 'workflow_dispatch' }}
     name: 'Pre-check'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       RELEASE_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
       HEAD: ${{ steps.version.outputs.HEAD }}
@@ -151,7 +151,7 @@ jobs:
   # Perform the release
   release:
     needs: [ precheck, build-cli ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v4
@@ -187,7 +187,7 @@ jobs:
     name: "Publish NPM Package"
     if: success()  # Run only if explicitly indicated and successful
     needs: [ precheck, build, build-cli, release ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v4
@@ -332,7 +332,7 @@ jobs:
     name: "Clean Up"
     if: ${{ needs.precheck.outputs.AUXILIARY_BRANCH != '' }}
     needs: [ precheck, build, build-cli, release, publish-npm-package ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/issue_comp_frontend-notify.yml
+++ b/.github/workflows/issue_comp_frontend-notify.yml
@@ -14,7 +14,7 @@ on:
         required: true
 jobs:
   resolve-data:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       issue_number: ${{ steps.evaluate-actions.outputs.issue_number }}
     steps:
@@ -152,7 +152,7 @@ jobs:
   frontend-notify:
     name: Notify team member ${{ matrix.member }}
     needs: [resolve-data, slack-channel-resolver]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: success() && needs.resolve-data.outputs.issue_number && needs.slack-channel-resolver.outputs.channel_ids
     strategy:
       fail-fast: false

--- a/.github/workflows/issue_comp_github-member-resolver.yml
+++ b/.github/workflows/issue_comp_github-member-resolver.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   github-member-resolver:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       members: ${{ steps.resolve-members.outputs.members }}
     steps:

--- a/.github/workflows/issue_comp_link-issue-to-pr.yml
+++ b/.github/workflows/issue_comp_link-issue-to-pr.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   add-issue-to-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - run: echo 'GitHub context'

--- a/.github/workflows/issue_comp_link-pr-to-issue.yml
+++ b/.github/workflows/issue_comp_link-pr-to-issue.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   link-pr-to-issue:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo 'GitHub context'
         env:

--- a/.github/workflows/issue_comp_next-release-label.yml
+++ b/.github/workflows/issue_comp_next-release-label.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   qa-not-needed-update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       QA_NOT_NEEDED_LABEL: 'QA : Not Needed'
       REPO: core

--- a/.github/workflows/issue_comp_release-labeling.yml
+++ b/.github/workflows/issue_comp_release-labeling.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   release-labeling:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       REPO: core
     steps:

--- a/.github/workflows/issue_manual_label-issues.yml
+++ b/.github/workflows/issue_manual_label-issues.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   label-issues:
     name: Label issues
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout core
         uses: actions/checkout@v4

--- a/.github/workflows/issue_on-change_assign-issues-to-qa-project.yml
+++ b/.github/workflows/issue_on-change_assign-issues-to-qa-project.yml
@@ -4,7 +4,7 @@ on:
     types: [labeled]
 jobs:
   assign_one_project:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Assign to QA Project
     env:
       QA_PROJECT_ID: 6

--- a/.github/workflows/issue_scheduled_stale-action.yml
+++ b/.github/workflows/issue_scheduled_stale-action.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   stale:
   
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -48,7 +48,7 @@ on:
 jobs:
   build-push-image:
     name: Build/Push Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_VERSION: 11
       JAVA_DISTRO: temurin

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       release_version: ${{ steps.set-common-vars.outputs.release_version }}
       release_tag: ${{ steps.set-common-vars.outputs.release_tag }}
@@ -216,7 +216,7 @@ jobs:
 
   release-process:
     name: Release Process
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare-release
     env:
       AWS_REGION: us-east-1
@@ -336,7 +336,7 @@ jobs:
 
   generate-sbom:
     name: Generate SBOM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [  prepare-release, build-push-image ]
     continue-on-error: true
     steps:
@@ -385,7 +385,7 @@ jobs:
 
   finish-release:
     name: Finish Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [prepare-release, release-process, build-push-image]
     if: success()
     steps:

--- a/.github/workflows/legacy-release_publish-docker-image-on-release.yml
+++ b/.github/workflows/legacy-release_publish-docker-image-on-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   prepare-build:
     name: Prepare build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       build_id: ${{ steps.process-params.outputs.build_id }}
     steps:
@@ -52,7 +52,7 @@ jobs:
   finish-build-push:
     name: Finish Build/Push
     needs: build-push-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Slack Notification
         if: success()

--- a/.github/workflows/legacy-release_publish-dotcms-docker-image.yml
+++ b/.github/workflows/legacy-release_publish-dotcms-docker-image.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   prepare-build:
     name: Prepare build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       ref: ${{ steps.set-common-vars.outputs.ref }}
       docker_platforms: ${{ steps.set-common-vars.outputs.docker_platforms }}

--- a/.github/workflows/legacy-release_release-candidate.yml
+++ b/.github/workflows/legacy-release_release-candidate.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   release-candidate-process:
     name: Release process automation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       ref: ${{ steps.set-common-vars.outputs.ref }}
     steps:
@@ -108,7 +108,7 @@ jobs:
 
   notification:
     name: Release process automation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [release-candidate-process, build_push_image]
     steps:
       -

--- a/.github/workflows/legacy-release_release-trigger.yml
+++ b/.github/workflows/legacy-release_release-trigger.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release-trigger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/legacy-release_sbom-generator.yaml
+++ b/.github/workflows/legacy-release_sbom-generator.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write  # Ensure write access to contents
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -7,7 +7,7 @@ on:
       - main
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/utility_discover-docker-tags.yml
+++ b/.github/workflows/utility_discover-docker-tags.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   discover_tags:
     name: Discover DotCMS docker tags
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: GITHUB CONTEXT
         env:

--- a/.github/workflows/utility_slack-channel-resolver.yml
+++ b/.github/workflows/utility_slack-channel-resolver.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   slack-channel-resolver:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       channel_ids: ${{ steps.resolve-channels.outputs.channel_ids }}
       mappings_json: ${{ steps.resolve-channels.outputs.mappings_json }}

--- a/tools/dotcms-cli/action/.github/workflows/main.yml
+++ b/tools/dotcms-cli/action/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
 
   dotcli-runner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       url: ${{ steps.dotcli-runner.outputs.url }}
     steps:
@@ -30,7 +30,7 @@ jobs:
 
   sync-with-dotcms:
     needs: dotcli-runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # Global environment expected by dotCMS CLI
       # This is how we instruct the cli the target server


### PR DESCRIPTION
### Proposed Changes

This pull request updates the GitHub Actions workflows to use Ubuntu 22.04 instead of using `latest` tag and older versions (like 20.04).

Key changes include:

* Updated the `runs-on` field to `ubuntu-22.04` across multiple workflow files to ensure consistency.