### PR TITLE
Small fix on SDK Publish versions

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -71,7 +71,7 @@ runs:
         # This should be empty on the first run. Setting the NEXT_VERSION to 0.0.1-beta.1
         CURRENT_VERSION=$(npm view @dotcms/client dist-tags --json | jq -r '.beta')
 
-        if [ -z "$CURRENT_VERSION" ]; then
+        if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "null" ]; then
           CURRENT_VERSION="0.0.1-beta.0"
         fi
 


### PR DESCRIPTION
This pull request includes a small but important change to the deployment script for the JavaScript SDK. The modification ensures that the `CURRENT_VERSION` is correctly set even if the retrieved version is `null`.

* [`.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml`](diffhunk://#diff-b47e2bc3507c79547b7f53206919f60585f49479fa09c01ee9ab15eb6bb4c068L74-R74): Updated the condition to check if `CURRENT_VERSION` is `null` and set it to `0.0.1-beta.0` if true.