### PR TITLE
feat: add organization membership security gate for Claude workflow

### DIFF
--- a/.github/actions/security/org-membership-check/README.md
+++ b/.github/actions/security/org-membership-check/README.md
@@ -1,0 +1,47 @@
+# Organization Membership Check Action
+
+This composite action checks if a GitHub user is a member of the dotCMS organization. It's used as a security gate to ensure only dotCMS organization members can trigger sensitive workflows like Claude code reviews.
+
+## Security Features
+
+- **Hardcoded Organization**: The organization name "dotCMS" is hardcoded and cannot be overridden
+- **No Information Leakage**: Does not distinguish between public/private membership in outputs
+- **Graceful Error Handling**: Returns clear status without exposing internal API details
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `username` | GitHub username to check | Yes | N/A |
+
+## Outputs
+
+| Output | Description | Possible Values |
+|--------|-------------|-----------------|
+| `is_member` | Boolean indicating membership | `true` or `false` |
+| `membership_status` | Detailed status | `member`, `non-member`, or `error` |
+
+## Usage
+
+```yaml
+- name: Check organization membership
+  id: membership-check
+  uses: ./.github/actions/security/org-membership-check
+  with:
+    username: ${{ github.actor }}
+
+- name: Conditional step based on membership
+  if: steps.membership-check.outputs.is_member == 'true'
+  run: echo "User is authorized"
+```
+
+## Implementation Details
+
+The action uses the GitHub CLI (`gh`) with the repository's `GITHUB_TOKEN` to check organization membership. It first attempts to check public membership, and if that fails, it attempts to check private membership (which requires appropriate permissions in organization repositories).
+
+## Security Considerations
+
+- Only checks membership in the dotCMS organization (hardcoded)
+- Does not expose whether membership is public or private
+- Logs authorization results without sensitive details
+- Uses repository's built-in `GITHUB_TOKEN` for API access

--- a/.github/actions/security/org-membership-check/action.yml
+++ b/.github/actions/security/org-membership-check/action.yml
@@ -1,0 +1,65 @@
+name: 'Organization Membership Check'
+description: 'Checks if a user is a member of the dotCMS organization'
+
+inputs:
+  username:
+    description: 'GitHub username to check'
+    required: true
+
+outputs:
+  is_member:
+    description: 'true if user is a member, false otherwise'
+    value: ${{ steps.check-membership.outputs.is_member }}
+  membership_status:
+    description: 'Membership status (member, non-member, error)'
+    value: ${{ steps.check-membership.outputs.membership_status }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check Organization Membership
+      id: check-membership
+      shell: bash
+      run: |
+        echo "Checking organization membership for user: ${{ inputs.username }} in dotCMS organization"
+
+        # Use GitHub CLI to check organization membership
+        # This uses the GITHUB_TOKEN which has read access to organization membership
+
+        set +e  # Don't exit on error, we want to handle it gracefully
+
+        # Check public membership first
+        gh api orgs/dotCMS/members/${{ inputs.username }} \
+          --jq '.login' 2>/dev/null
+
+        exit_code=$?
+
+        if [ $exit_code -eq 0 ]; then
+          echo "✅ User ${{ inputs.username }} is a member of dotCMS"
+          echo "is_member=true" >> $GITHUB_OUTPUT
+          echo "membership_status=member" >> $GITHUB_OUTPUT
+        else
+          # If public membership check fails, try to check private membership
+          # This requires higher permissions but will work in organization repos
+          gh api orgs/dotCMS/members/${{ inputs.username }} \
+            --method GET \
+            --header "Accept: application/vnd.github.v3+json" 2>/dev/null
+
+          private_exit_code=$?
+
+          if [ $private_exit_code -eq 0 ]; then
+            echo "✅ User ${{ inputs.username }} is a member of dotCMS"
+            echo "is_member=true" >> $GITHUB_OUTPUT
+            echo "membership_status=member" >> $GITHUB_OUTPUT
+          else
+            echo "❌ User ${{ inputs.username }} is not a member of dotCMS"
+            echo "is_member=false" >> $GITHUB_OUTPUT
+            echo "membership_status=non-member" >> $GITHUB_OUTPUT
+          fi
+        fi
+
+        # Log the result for debugging (without leaking membership details)
+        membership_result=$(if [ "$(cat $GITHUB_OUTPUT | grep 'is_member=true')" ]; then echo "AUTHORIZED"; else echo "UNAUTHORIZED"; fi)
+        echo "::notice::Organization membership check result: $membership_result for ${{ inputs.username }}"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/issue_comment_claude-code-review.yaml
+++ b/.github/workflows/issue_comment_claude-code-review.yaml
@@ -19,8 +19,34 @@ on:
     types: [created]
 
 jobs:
+  # Security gate: Check if user is dotCMS organization member
+  security-check:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.membership-check.outputs.is_member }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check organization membership
+        id: membership-check
+        uses: ./.github/actions/security/org-membership-check
+        with:
+          username: ${{ github.event.comment.user.login || github.actor }}
+
+      - name: Log security decision
+        run: |
+          if [ "${{ steps.membership-check.outputs.is_member }}" = "true" ]; then
+            echo "✅ Access granted: User is a dotCMS organization member"
+          else
+            echo "❌ Access denied: User is not a dotCMS organization member"
+            echo "::warning::Unauthorized user attempted to trigger Claude workflow: ${{ github.event.comment.user.login || github.actor }}"
+          fi
+
   # Interactive Claude mentions (simplified using centralized logic)
   claude-interactive:
+    needs: security-check
+    if: needs.security-check.outputs.authorized == 'true'
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: interactive


### PR DESCRIPTION
- Create reusable org-membership-check action to verify dotCMS membership
- Update Claude workflow with security gate that blocks non-members
- Hardcode organization to prevent override attacks
- Add comprehensive logging for security decisions

Addresses security concern from issue #33050 where external users could trigger Claude workflows by mentioning @claude in comments.

🤖 Generated with [Claude Code](https://claude.ai/code)

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
