### PR TITLE
fix(ci): add SDKMAN_JAVA_VERSION build arg to docker build in maven-job

### DIFF
--- a/.github/actions/core-cicd/maven-job/action.yml
+++ b/.github/actions/core-cicd/maven-job/action.yml
@@ -238,6 +238,20 @@ runs:
         name: docker-build-context
         path: dotCMS/target/docker-build.tar
 
+    - id: get-sdkman-version
+      name: Get SDKMan Version
+      if: ${{ inputs.generate-docker == 'true' }}
+      shell: bash
+      run: |
+        if [ -f .sdkmanrc ]; then
+          SDKMAN_JAVA_VERSION=$(awk -F "=" '/^java=/ {print $2}' .sdkmanrc)
+          echo "using default Java version from .sdkmanrc: ${SDKMAN_JAVA_VERSION}"
+          echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}" >> $GITHUB_OUTPUT
+        else
+          echo "No .sdkmanrc file found"
+          exit 1
+        fi
+
     - id: build-docker-image-from-archive
       name: Build Docker Image from Archive
       if: ${{ inputs.generate-docker == 'true' }}
@@ -247,8 +261,11 @@ runs:
         mkdir -p /tmp/docker-context
         tar -xf dotCMS/target/docker-build.tar -C /tmp/docker-context
 
-        # Build the Docker image from the extracted context
-        docker build -t dotcms/dotcms-test:${{ inputs.version }} /tmp/docker-context
+        # Build the Docker image from the extracted context with required build arguments
+        docker build \
+          --build-arg SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }} \
+          -t dotcms/dotcms-test:${{ inputs.version }} \
+          /tmp/docker-context
 
         # Verify the image was created
         docker images dotcms/dotcms-test:${{ inputs.version }}


### PR DESCRIPTION
Fixes the docker build failure caused by missing SDKMAN_JAVA_VERSION build argument.

## Changes
- Added step to extract SDKMAN_JAVA_VERSION from .sdkmanrc
- Pass SDKMAN_JAVA_VERSION as --build-arg to docker build command
- Matches the pattern used in deployment-phase.yml

## Why needed
The Dockerfile requires SDKMAN_JAVA_VERSION to select the correct Java base image.

🤖 Generated with Claude Code