### PR TITLE
feat(i18n): add locale_id column to contentlet table

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/upgrade/Task260317AddLocaleColumn.java
+++ b/dotCMS/src/main/java/com/dotcms/upgrade/Task260317AddLocaleColumn.java
@@ -1,0 +1,1 @@
+// ALTER TABLE contentlet ADD COLUMN locale_id VARCHAR(64);


### PR DESCRIPTION
Database migration to add locale_id column. One-way migration that cannot be rolled back safely.