### PR TITLE
ci: upgrade base Docker image to eclipse-temurin:21-jre-noble

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,1 @@
+FROM eclipse-temurin:21-jre-noble


### PR DESCRIPTION
Upgraded base image from jammy to noble (24.04 LTS) for security patches.