### PR TITLE
test: validate SDKMAN bash fix on macOS and Linux runners

### DIFF
--- a/.github/actions/core-cicd/setup-java/action.yml
+++ b/.github/actions/core-cicd/setup-java/action.yml
@@ -61,14 +61,29 @@ runs:
       with:
         path: ~/.sdkman
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
+    - name: Install Bash 4+ (macOS)
+      if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' && runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        # macOS ships Bash 3.2 but SDKMAN 5.21+ requires Bash 4+.
+        # Homebrew is pre-installed on GitHub macOS runners.
+        brew install bash
+        echo "Installed Bash: $($(brew --prefix)/bin/bash --version | head -1)"
     - name: Install SDKMan
       id: install-sdkman
       if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
-        echo "Downloading SDKMAN install"
-        curl -s "https://get.sdkman.io" | bash
+          echo "Downloading SDKMAN install"
+          # Use Homebrew bash on macOS (Bash 4+), system bash on Linux (already 5.x)
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            BREW_BASH="$(brew --prefix)/bin/bash"
+            echo "Using Homebrew bash: $($BREW_BASH --version | head -1)"
+            curl -s "https://get.sdkman.io" | "$BREW_BASH"
+          else
+            curl -s "https://get.sdkman.io" | bash
+          fi
         fi
     - name: Save Cache SDKMan install
       id: save-cache-sdkman

--- a/.github/workflows/test_sdkman-bash-fix.yml
+++ b/.github/workflows/test_sdkman-bash-fix.yml
@@ -1,0 +1,39 @@
+name: Test SDKMAN Bash Fix
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/actions/core-cicd/setup-java/**'
+      - '.github/workflows/test_sdkman-bash-fix.yml'
+
+jobs:
+  test-setup-java:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            label: Linux
+          - os: macos-15
+            label: macOS-Silicon
+          - os: macos-15-intel
+            label: macOS-Intel
+    runs-on: ${{ matrix.os }}
+    name: Setup Java (${{ matrix.label }})
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show system bash version
+        shell: bash
+        run: |
+          echo "System bash: $(bash --version | head -1)"
+          echo "Runner OS: $RUNNER_OS"
+          echo "Architecture: $(uname -m)"
+      - name: Setup Java via SDKMAN
+        uses: ./.github/actions/core-cicd/setup-java
+      - name: Verify Java
+        shell: bash
+        run: |
+          echo "JAVA_HOME=$JAVA_HOME"
+          java -version
+          echo "Success!"


### PR DESCRIPTION
## Summary

Tests the fix for dotCMS/core#35004 — installs Homebrew bash (4+) on macOS runners before running SDKMAN installer.

Runs setup-java on:
- Ubuntu 24.04 (Linux baseline)
- macOS 15 Silicon
- macOS 15 Intel

**Delete this branch after testing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)