### PR TITLE
test: validate graceful Claude API skip (dotCMS/core#35328)

### DIFF
--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -80,7 +80,7 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@feat/35328-graceful-api-unavailability
     with:
       trigger_mode: interactive
       claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
@@ -108,7 +108,7 @@ jobs:
       !contains(github.event.pull_request.body, '@claude') &&
       !contains(github.event.pull_request.body, '@Claude') &&
       !contains(github.event.pull_request.body, '@CLAUDE')
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@feat/35328-graceful-api-unavailability
     with:
       trigger_mode: automatic
       prompt: |
@@ -136,7 +136,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@feat/35328-graceful-api-unavailability
     with:
       trigger_mode: automatic
       prompt: |

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -80,7 +80,7 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@feat/35328-graceful-api-unavailability
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.1.0
     with:
       trigger_mode: interactive
       claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
@@ -108,7 +108,7 @@ jobs:
       !contains(github.event.pull_request.body, '@claude') &&
       !contains(github.event.pull_request.body, '@Claude') &&
       !contains(github.event.pull_request.body, '@CLAUDE')
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@feat/35328-graceful-api-unavailability
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.1.0
     with:
       trigger_mode: automatic
       prompt: |
@@ -136,7 +136,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@feat/35328-graceful-api-unavailability
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.1.0
     with:
       trigger_mode: automatic
       prompt: |


### PR DESCRIPTION
## Summary

This PR tests the fix from dotCMS/ai-workflows@feat/35328-graceful-api-unavailability.

The Claude orchestrator now:
1. Checks the Anthropic API availability before running
2. Skips gracefully with a warning when the API returns 5xx or is unreachable
3. Re-checks after runtime failures to distinguish service outages from real errors

## What to verify

- The `claude-automatic-review` and `claude-rollback-safety-check` jobs should run successfully
- The pre-flight check step should show `✅ Claude API is available` in the logs
- If the API were down, the jobs would show a warning and pass (not fail)

Ref: dotCMS/core#35328