### PR TITLE
feat(ci): extend rollback-safety workflow with doc-object generation

### DIFF
--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -1,0 +1,276 @@
+name: Claude AI Rollback Safety Check + Doc Object Generation
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+
+jobs:
+  # Security gate: Check if user is dotCMS organization member
+  #
+  # REQUIREMENTS FOR CLAUDE ACCESS:
+  # 1. Must be a member of the dotCMS organization
+  # 2. Membership must be set to PUBLIC visibility
+  #
+  # TROUBLESHOOTING: If blocked, visit https://github.com/orgs/dotCMS/people
+  # and ensure your membership is public (click "Make public" if needed)
+  security-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      authorized: ${{ steps.membership-check.outputs.is_member }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check organization membership
+        id: membership-check
+        uses: ./.github/actions/security/org-membership-check
+        with:
+          username: ${{ github.event.pull_request.user.login || github.actor }}
+
+      - name: Log security decision
+        run: |
+          if [ "${{ steps.membership-check.outputs.is_member }}" = "true" ]; then
+            echo "✅ Access granted: User is a dotCMS organization member"
+          else
+            echo "❌ Access denied: User failed dotCMS organization membership check"
+            echo ""
+            echo "📋 TROUBLESHOOTING: If you are a dotCMS team member:"
+            echo "   1. Visit https://github.com/orgs/dotCMS/people"
+            echo "   2. Ensure your membership is set to 'Public'"
+            echo "   3. If you're not listed, contact an organization owner"
+            echo ""
+            echo "::warning::Unauthorized user attempted to trigger Claude workflow: ${{ github.event.pull_request.user.login || github.actor }}"
+          fi
+
+  # Preflight: clear stale AI rollback labels so each push is re-evaluated from scratch,
+  # and skip the whole AI evaluation when the PR author has already classified the change
+  # via a "Human: ..." label (skip cascades to claude-rollback-safety-check via needs/success()).
+  # Only runs pre-merge (opened/synchronize) — not on PR close.
+  preflight-clear-stale-labels:
+    name: Clear stale AI rollback labels
+    needs: security-check
+    if: |
+      github.event.action != 'closed' &&
+      needs.security-check.outputs.authorized == 'true' &&
+      !contains(github.event.pull_request.labels.*.name, 'Human: Safe To Rollback') &&
+      !contains(github.event.pull_request.labels.*.name, 'Human: Not Safe To Rollback')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Remove stale AI rollback labels so this push is re-evaluated
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # `gh pr edit --remove-label` returns non-zero if the label is not on the PR.
+          # Swallow that so we don't need a pre-check fetch; any other failure is cosmetic.
+          for label in "AI: Not Safe To Rollback" "AI: Safe To Rollback"; do
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$label" || true
+          done
+
+  # Combined analysis — runs on every PR push (pre-merge only).
+  # Single diff comprehension pass produces two outputs:
+  #   1. Doc-object draft  →  posted as a collapsible PR comment (extracted post-merge)
+  #   2. Rollback safety   →  label + optional comment (immediate)
+  #
+  # Doc object is generated first (factual summary before evaluative judgment).
+  claude-rollback-safety-check:
+    needs: [security-check, preflight-clear-stale-labels]
+    concurrency:
+      group: claude-rollback-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    if: |
+      github.event.action != 'closed' &&
+      needs.security-check.outputs.authorized == 'true'
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      issues: write
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.1.0
+    with:
+      trigger_mode: automatic
+      prompt: |
+        You are a dotCMS diff analyst. A PR has been pushed. Using a single read of the diff,
+        you will produce two outputs: first a documentation object (factual summary), then a
+        rollback-safety assessment (evaluative judgment). Collect all inputs before writing either output.
+
+        STEP 1 — Read the doc-object generation schema and instructions:
+          cat prompts/doc_object_generation.md
+
+        STEP 2 — Read the rollback-unsafe categories reference:
+          cat docs/core/ROLLBACK_UNSAFE_CATEGORIES.md
+
+        STEP 3 — Fetch PR metadata:
+          gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json number,title,body,labels,mergedAt,headRefName
+
+        STEP 4 — Get the full PR diff:
+          git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+        STEP 5 — Fetch any linked issues. Parse "closes #N" / "fixes #N" / "resolves #N" patterns
+          from the PR body, then for each issue number N:
+          gh issue view N --repo ${{ github.repository }} --json number,title,body
+
+        ── OUTPUT A: DOC OBJECT ──────────────────────────────────────────────────────────
+
+        STEP 6 — Generate the doc object following the schema in the "## System Prompt" section
+          of prompts/doc_object_generation.md. For the commit SHA fields, use these exact placeholders
+          (the post-merge attach job will substitute the real values):
+            commit: PLACEHOLDER_SHORT_SHA
+            source_diff_sha: PLACEHOLDER_FULL_SHA
+
+          Write the doc object to /tmp/doc-object.md:
+          python3 -c "
+          content = '''<your generated doc object here>'''
+          open('/tmp/doc-object.md', 'w').write(content)
+          "
+
+        STEP 7 — Post the doc object as a collapsible PR comment so the post-merge job can
+          retrieve and attach it to the merge commit. Write the comment body to a temp file first
+          to avoid shell quoting issues, then post it:
+
+          python3 -c "
+          doc = open('/tmp/doc-object.md').read()
+          comment = f'''<!-- doc-object-draft-start -->
+        <details>
+        <summary>📄 Doc Object Draft (attached to merge commit post-merge)</summary>
+
+        {doc}
+        </details>
+        <!-- doc-object-draft-end -->'''
+          open('/tmp/doc-object-comment.md', 'w').write(comment)
+          "
+
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/doc-object-comment.md
+
+        ── OUTPUT B: ROLLBACK SAFETY ─────────────────────────────────────────────────────
+
+        STEP 8 — Analyze the diff against EVERY category in the ROLLBACK_UNSAFE_CATEGORIES.md
+          reference you read in Step 2. Focus on: database migrations (runonce tasks),
+          Elasticsearch mapping changes, data model changes, API contract changes, and any
+          structural storage changes. Ignore pure UI, test-only, or documentation changes
+          unless they touch an unsafe category.
+
+        STEP 9a — If the changes match one or more unsafe categories, post this comment:
+          gh pr comment ${{ github.event.pull_request.number }} --body "..."
+
+          Format:
+          Pull Request Unsafe to Rollback!!!
+          - Category: <category ID and name, e.g. "C-1 — Structural Data Model Change">
+          - Risk Level: <🔴 CRITICAL / 🟠 HIGH / 🟡 MEDIUM / 🟢 LOW>
+          - Why it's unsafe: <specific explanation tied to the actual code changed>
+          - Code that makes it unsafe: <file path(s) and the specific lines or block>
+          - Alternative (if possible): <the safer alternative from the reference, adapted to this change>
+
+          If multiple categories match, repeat the block for each one.
+
+          Then add the label:
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "AI: Not Safe To Rollback"
+
+        STEP 9b — If the changes do NOT match any unsafe category:
+          Only add the label:
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "AI: Safe To Rollback"
+          No comment needed.
+
+        Be specific throughout: quote actual file names and code lines, not generic descriptions.
+      claude_args: >-
+        --allowedTools
+        "Bash(cat prompts/doc_object_generation.md),
+        Bash(cat docs/core/ROLLBACK_UNSAFE_CATEGORIES.md),
+        Bash(git diff*),
+        Bash(git log*),
+        Bash(gh pr view*),
+        Bash(gh pr comment*),
+        Bash(gh pr edit*),
+        Bash(gh issue view*),
+        Bash(python3*)"
+      timeout_minutes: 15
+      runner: ubuntu-latest
+      enable_mention_detection: false
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  # Post-merge: attach the doc-object draft to the squash commit via git notes.
+  # No LLM call — pure shell. Reads the draft comment posted pre-merge, substitutes
+  # the real merge SHA, and writes to refs/notes/doc-objects.
+  doc-object-attach:
+    name: Attach doc object to merge commit
+    needs: security-check
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      needs.security-check.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch existing doc-objects notes ref
+        run: |
+          git fetch origin refs/notes/doc-objects:refs/notes/doc-objects 2>/dev/null || true
+
+      - name: Extract doc object draft from PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          python3 - << 'PYEOF'
+          import subprocess, sys, re, os
+
+          pr_number = os.environ['PR_NUMBER']
+          repo = os.environ['REPO']
+          merge_sha = os.environ['MERGE_SHA']
+          short_sha = merge_sha[:7]
+
+          # Fetch all PR comment bodies
+          result = subprocess.run(
+              ['gh', 'pr', 'view', pr_number, '--repo', repo,
+               '--json', 'comments', '--jq', '.comments[].body'],
+              capture_output=True, text=True, check=True
+          )
+
+          # Find the doc-object-draft block
+          text = result.stdout
+          match = re.search(
+              r'<!-- doc-object-draft-start -->(.*?)<!-- doc-object-draft-end -->',
+              text, re.DOTALL
+          )
+          if not match:
+              print('ERROR: No doc-object-draft comment found on this PR.', file=sys.stderr)
+              print('This likely means the pre-merge Claude analysis did not complete.', file=sys.stderr)
+              sys.exit(1)
+
+          # Strip the <details> wrapper — extract just the raw doc object
+          block = match.group(1)
+          inner = re.search(r'</summary>\s*\n(.*?)\n</details>', block, re.DOTALL)
+          draft = inner.group(1).strip() if inner else block.strip()
+
+          # Substitute the SHA placeholders
+          draft = draft.replace('PLACEHOLDER_SHORT_SHA', short_sha)
+          draft = draft.replace('PLACEHOLDER_FULL_SHA', merge_sha)
+
+          with open('/tmp/doc-object.md', 'w') as f:
+              f.write(draft)
+
+          print(f'Extracted doc object ({len(draft)} chars) for commit {short_sha}')
+          PYEOF
+
+      - name: Attach doc object to merge commit via git notes
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          git notes --ref=refs/notes/doc-objects add -F /tmp/doc-object.md "$MERGE_SHA"
+          git push origin refs/notes/doc-objects
+          echo "✅ Doc object attached to $MERGE_SHA and pushed to refs/notes/doc-objects"

--- a/prompts/doc_object_generation.md
+++ b/prompts/doc_object_generation.md
@@ -1,0 +1,236 @@
+# Doc-Object Generation Prompt
+# Version: v0.1
+#
+# Usage:
+#   SYSTEM PROMPT: everything under "## System Prompt"
+#   USER MESSAGE:  the "## User Message Template" section, with variables substituted
+#
+# Variables injected at call time (CI script responsibility):
+#   {{SHORT_SHA}}       — 7-char abbreviated commit SHA
+#   {{FULL_SHA}}        — full 40-char commit SHA
+#   {{PR_NUMBER}}       — primary PR number (the one that merged to main)
+#   {{ORIGINAL_PR}}     — original PR if this is a backport; same as PR_NUMBER if not
+#   {{TITLE}}           — PR title (already conventional-commit-style in dotCMS)
+#   {{MERGED_AT}}       — ISO 8601 merge timestamp
+#   {{LABELS}}          — comma-separated label names
+#   {{BRANCH}}          — head branch name
+#   {{PR_BODY}}         — full PR description text
+#   {{DIFF}}            — truncated unified diff (≤10 files, ≤4000 chars/file)
+#   {{LINKED_ISSUES}}   — newline-delimited "#{number}: {title}\n{body excerpt}" blocks, or "(none)"
+#   {{GENERATED_AT}}    — ISO 8601 timestamp of generation (injected by CI, not model)
+#   {{MODEL_ID}}        — model identifier used for generation (injected by CI)
+#   {{PROMPT_VERSION}}  — prompt version string (injected by CI, e.g. "v0.1")
+
+---
+
+## System Prompt
+
+You are a documentation analyst for dotCMS, an enterprise Java + Angular content management
+platform used by large organizations for web experience management. Your job is to analyze a
+merged GitHub pull request and produce a structured **doc object** — a compact, pre-analyzed
+artifact stored as a git note on the merge commit and consumed by downstream documentation
+pipelines: release note generation, CMS page update identification, and internal changelogs.
+
+The doc object has two parts:
+
+1. **YAML frontmatter** — machine-readable structured metadata used for filtering and routing
+2. **Markdown body** — human- and LLM-readable prose, free-form but drawn from a defined menu
+
+Your output must be **only** the doc object (YAML block + markdown body). No preamble, no
+explanation, no commentary outside the doc object itself.
+
+---
+
+### YAML Frontmatter Schema
+
+Produce exactly this structure. **Omit optional fields entirely** when they don't apply — do not
+include them with null or empty values.
+
+```yaml
+---
+commit: <7-char short SHA>
+title: "<conventional-commit-style title — copy from PR title if already well-formed>"
+type: <feature | bugfix | refactor | docs | chore | security | ci | test | revert>
+module: "<affected product area in plain English, e.g. 'page-cache/vanity-url', 'maintenance REST API', 'UVE/edit-content', 'categories API'>"
+customer_visible: <yes | no | indirect>
+security_relevant: <true | false>
+breaking_change: <true | false>
+
+# Conditionally included:
+severity: <critical | high | medium | low>      # bugs and security only; omit for features/chores/refactors
+feature_flag: "<FLAG_CONSTANT_NAME>"             # if the change is gated; omit if not
+pr:
+  primary: <PR number that landed on main>
+  original: <original PR number if this is a backport; omit if same as primary>
+  backports: [<PR numbers of subsequent backport PRs, if known>]
+related_prs: [<N>, ...]                          # PRs in the same fix family; omit if none
+customer_reports:
+  - source: <freshdesk | github | jira | zendesk>
+    id: "<ticket id as a string>"
+
+release_notes:
+  audience: <customer | internal | both | skip>
+  priority: <high | medium | low>
+  reasoning: "<one sentence justifying the audience and priority call>"
+
+provenance:
+  generator: doc-object-skill
+  model: <model-id>
+  prompt_version: <prompt-version>
+  generated_at: <ISO 8601 timestamp>
+  source_pr: <PR number>
+  source_diff_sha: <full 40-char merge commit SHA>
+---
+```
+
+---
+
+### Classification heuristics
+
+**`type`**
+Infer from the commit/PR prefix: `feat`→`feature`, `fix`→`bugfix`, `refactor`→`refactor`,
+`docs`→`docs`, `chore`→`chore`, `test`→`test`, `ci`→`ci`, `revert`→`revert`.
+If the fix closes an active injection vector or authentication/authorization gap, use `security`
+in preference to `bugfix` — the downstream security-review gate depends on this distinction.
+
+**`module`**
+A short, human-readable area label. Use the PR scope hint (e.g. `fix(page-cache):` → `page-cache`)
+as the primary signal, enriched from the diff paths. Prefer product-area terms over Java package
+names. Examples: `maintenance REST API`, `UVE/edit-content`, `categories API`, `page-cache`,
+`content analytics`, `push publishing`, `dot AI`.
+
+**`customer_visible`**
+- `yes` — the change directly affects behavior a customer, end user, or API consumer can observe:
+  UI change, new/changed REST endpoint, bug that was producing wrong output, new feature.
+- `no` — purely internal: CI config, test-only change, internal concurrency fix with no observable
+  output change, vendored-code update with no API surface change.
+- `indirect` — infrastructure or abstraction change with no current observable consumer:
+  new internal API not yet exposed, config option not yet documented, dependency bump that
+  changes behavior only under edge conditions.
+
+**`security_relevant`**
+Set `true` if the change: closes an injection vector (SQL, XSS, SSTI, etc.), fixes an
+authentication or authorization gap, addresses a data-isolation failure (multi-tenant content
+bleed is a security-relevant correctness bug), or involves credential/token handling.
+When borderline, lean `true` — this field triggers a human review gate before the doc object
+flows into public release notes, so a false positive is harmless; a false negative is not.
+
+**`breaking_change`**
+Set `true` if: a public REST endpoint changes its request or response shape, a configuration
+property is removed or renamed, a previously-documented behavior changes in a way that
+requires customer action. Package-private visibility changes and internal refactors are not
+breaking changes.
+
+**`severity`** (bugs and security only)
+- `critical` — data integrity violation, multi-tenant content bleed, authentication bypass,
+  data loss under normal operation.
+- `high` — customers are actively experiencing wrong behavior; no acceptable workaround; or
+  significant performance regression under normal load.
+- `medium` — real bug with limited blast radius, or a workaround exists.
+- `low` — cosmetic, edge case, or the fix is better characterized as cleanup.
+
+**`release_notes.audience`**
+- `customer` — the change fixes something customers experienced or adds something they can use.
+- `internal` — affects only engineering operations: CI, internal tooling, test infrastructure,
+  internal correctness fixes with no observable behavior change.
+- `both` — affects engineering practice AND customer-facing behavior (e.g. a new admin endpoint
+  that also fixes a customer-reported bug).
+- `skip` — pure noise: vendored code, generated-code update, version bump with no behavior change,
+  revert-of-revert. Internal concurrency fixes with zero customer-visible effect are also `skip`.
+
+---
+
+### Markdown Body
+
+After the closing `---` of the YAML frontmatter, write the body in free-form markdown.
+Choose sections from this menu based on what the change actually warrants.
+**Do not write empty or inapplicable sections.**
+
+**Always include:**
+
+- `## What changed` — 2–5 sentences. Describe the behavior before and after in terms a support
+  engineer or technical writer can act on. Do not summarize the diff; describe the effect on
+  real usage.
+
+**Include when the change warrants it:**
+
+- `## Why it matters` — for high/critical bugs or non-obvious features, one focused paragraph
+  on real-world impact (who is affected, what goes wrong without this fix, what changes for them).
+
+- `## Feature flag` — if gated behind a flag: flag name, granularity
+  (`global | per-content-type | per-user | per-request`), and the fallback behavior when the
+  flag is off.
+
+- `## API surface` — for new or changed REST endpoints: HTTP method, path, brief description of
+  request/response. Link to OpenAPI/Swagger path if the diff adds or modifies it.
+
+- `## Configuration` — for new or changed env vars, system properties, or dotMarketing
+  properties: name, type, default value, and effect. Present as a small table if ≥3 entries.
+
+- `## Migration / deprecation` — if this replaces something a customer currently uses:
+  what is replaced, what replaces it, and the migration path.
+
+- `## Related` — cross-PR or cross-issue narrative that a reader needs to understand the full
+  picture (e.g., "This completes the fix started in #NNNNN, which addressed the same collision
+  class for URL-mapped contentlets.").
+
+- `## Risk / watch` — non-obvious downstream effects, bundle composition changes, cluster
+  behavior notes, callouts for the support team.
+
+**Do not include:**
+
+- Implementation details that don't affect behavior (class names, refactored method signatures,
+  internal test scaffolding)
+- Content already fully expressed in the YAML frontmatter (don't restate severity in prose
+  if it's captured in the field)
+- Speculation about future use cases or roadmap
+
+---
+
+### Token budget
+
+Target **300–500 tokens** for the complete doc object (frontmatter + body combined).
+If you are running over, trim body prose first; the frontmatter fields are non-negotiable.
+Body prose should be dense and direct — one sentence where one sentence suffices.
+A doc object that fits in 350 tokens and captures the key facts is better than one that
+fills 600 tokens and repeats itself.
+
+---
+
+## User Message Template
+
+The following PR was merged to `main`. Produce a doc object for its merge commit.
+
+**Merge commit:** `{{FULL_SHA}}` (short: `{{SHORT_SHA}}`)
+**PR:** #{{PR_NUMBER}}{{ORIGINAL_PR_NOTE}}
+**Title:** {{TITLE}}
+**Merged at:** {{MERGED_AT}}
+**Labels:** {{LABELS}}
+**Branch:** {{BRANCH}}
+
+**Provenance to embed verbatim in frontmatter:**
+```
+model: {{MODEL_ID}}
+prompt_version: {{PROMPT_VERSION}}
+generated_at: {{GENERATED_AT}}
+```
+
+---
+
+### PR Description
+
+{{PR_BODY}}
+
+---
+
+### Linked issues
+
+{{LINKED_ISSUES}}
+
+---
+
+### Diff (truncated)
+
+```diff
+{{DIFF}}
+```


### PR DESCRIPTION
### Proposed Changes

* Extends `ai_claude-rollback-safety.yml` to produce two outputs from a single diff-comprehension pass per PR:
  1. **Doc-object draft** — a structured YAML + markdown summary of the change, posted as a collapsible PR comment pre-merge and attached to the squash commit via `git notes` post-merge
  2. **Rollback safety assessment** — existing behavior, unchanged
* Adds `prompts/doc_object_generation.md` — the schema, classification heuristics, and body-section guidance the model follows when generating a doc object
* Adds a new `doc-object-attach` job (pure shell, no LLM call) that fires on `pull_request: closed` + `merged == true`, reads the draft comment, substitutes the real merge SHA for placeholders, and pushes to `refs/notes/doc-objects`
  
### Why
  
Doc objects are pre-analyzed, commit-bound summaries intended to make downstream documentation pipelines cheaper — a release-notes generator or doc-update pipeline can consume pre-computed doc objects for a commit range without re-reading every diff. Attaching them at merge time via `git notes` keeps the working tree clean and the notes fetchable as a separate ref.
  
Piggybacking on the existing rollback-safety workflow means one diff read per PR instead of two, halving the token cost of the combined operation.
  
### Rollback safety
  
This change touches only CI configuration and a markdown prompt file. No Java, no database, no Elasticsearch mappings, no public API surface. Safe to roll back by reverting this PR.
  
### Checklist
- [x] Tests — workflow behavior verified via this PR itself
- [x] Translations — N/A
- [x] Security Implications Contemplated — Claude access remains gated by the existing org-membership check; no new secrets required; `doc-object-attach` has `contents: write` + `pull-requests: read` only


