### PR TITLE
fix(ci): hardcode model ID in provenance rather than self-reporting

### DIFF
--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -129,10 +129,16 @@ jobs:
         ── OUTPUT A: DOC OBJECT ──────────────────────────────────────────────────────────
 
         STEP 6 — Generate the doc object following the schema in the "## System Prompt" section
-          of prompts/doc_object_generation.md. For the commit SHA fields, use these exact placeholders
-          (the post-merge attach job will substitute the real values):
-            commit: PLACEHOLDER_SHORT_SHA
+          of prompts/doc_object_generation.md. For the provenance block, copy these exact values
+          verbatim — do not infer or reformat any of them:
+            generator: doc-object-skill
+            model: claude-opus-4-8-20251001
+            prompt_version: v0.1
+            generated_at: <current UTC time in ISO 8601 format, e.g. 2026-06-05T11:36:00Z>
+            source_pr: <PR number from Step 3>
             source_diff_sha: PLACEHOLDER_FULL_SHA
+          For the commit short SHA field, use this exact placeholder:
+            commit: PLACEHOLDER_SHORT_SHA
 
           Write the doc object to /tmp/doc-object.md:
           python3 -c "


### PR DESCRIPTION
Some ANSI cruft was making it into the model name supplied. Its first response was to add some regexes to remove it, but I argued that manual string editing leaves open avenues for surprises, so surely it'd be better to fix the issue where it's generated. It responded by saying "ok let's just hardcode it." Whatever, good enough.

[1m] garbage in the model name

> What's happening: the doc object's provenance block is supposed to record which AI model generated it. The prompt tells Claude to fill in its own model ID. When Claude does this inside the CI runner, it reads its identifier from its environment — but that value has invisible terminal formatting codes attached to it (the [1m] is a "bold text" instruction meant for a terminal display, not for a YAML file). It ends up written to the note as literal characters.
> 
> Why it matters: the provenance block is meant to be machine-readable. Downstream tooling that parses YAML notes will get claude-opus-4-8[1m] instead of claude-opus-4-8, which could cause parse errors or mismatches when checking which prompt version generated a note.
> 
> The fix is to just tell Claude the exact string to write, the same way we already handle the SHAs with PLACEHOLDER_* values. The model name is known at workflow-authoring time; it should live in the workflow as a hardcoded literal, not be self-reported.

I asked if there are any downsides to this approach. Included for thoroughness:

> One real one: the hardcoded model name will silently go stale if the orchestrator switches models without a matching workflow update.
> 
> If someone updates the orchestrator to use claude-opus-4-9 but forgets to bump model: in this prompt, every doc object generated afterward will claim to be from claude-opus-4-8-20251001. The provenance block exists precisely for regeneration audits — "was this generated by an old model?" — and a stale value defeats that purpose.
> 
> The mitigation is process, not code: treat the model: line here the same as prompt_version: — both get bumped together whenever the orchestrator model changes. If that discipline holds, the stale value risk is low. If the team is loose about it, it becomes a quiet data quality problem.
> 
> The two other approaches worth knowing about:
> 
> Inject the model as a workflow variable — pass it in from the workflow's with: block as a GitHub Actions expression so it's set once at the top of the file, clearly visible, and easy to update. This doesn't solve the staleness risk but at least makes the value easy to spot and change. Whether the orchestrator supports passing arbitrary env vars through is the unknown — worth checking with the original author.
> 
> Drop the model: field from the schema — the prompt_version: field already anchors regeneration audits. You can always look up which model was active at a given prompt version. If you're willing to accept that indirect lookup, removing model: entirely eliminates the problem without any tradeoff.
> 
> For now the hardcoded approach is fine — it's better than ANSI garbage and the staleness risk is low given how infrequently models change relative to prompt iterations. But worth flagging to whoever owns the workflow long-term.
