### PR TITLE
fix(ci): revert test bypass, restore org membership check

### DIFF
--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      authorized: 'true'  # TEST BYPASS — revert before deploying to core
+      authorized: ${{ steps.membership-check.outputs.is_member }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Undoing the test bypass. Shouldn't be needed further, anyway, since my org membership is now public.