### PR TITLE
Use AUTODOC_TOKEN for dotcms-aios checkout

### DIFF
--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotCMS/dotcms-aios
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTODOC_TOKEN }}
           path: dotcms-aios
 
       - name: Set up uv


### PR DESCRIPTION
dotcms-aios is a private repo; GITHUB_TOKEN is scoped to core-workflow-test only. Switch to AUTODOC_TOKEN which has org-level read access.