### PR TITLE
Write eval context to file before passing to Claude

### DIFF
--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -118,7 +118,9 @@ jobs:
             --repo "$REPO" \
             --prompt burlap \
             --aios-dir ../dotcms-aios \
-          | claude --print --allowedTools Bash,Write
+            > /tmp/eval_context.md
+
+          claude --print --allowedTools Bash,Write < /tmp/eval_context.md
 
       - name: Run finalize (apply + post comment + commit)
         working-directory: autodoc


### PR DESCRIPTION
Claude CLI timed out waiting for stdin because run_eval.py was still fetching from GitHub. Write output to a temp file first, then feed it to Claude via stdin redirect.