### PR TITLE
Write eval context to file before passing to Claude (stdin fix)

### DIFF
--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -118,7 +118,9 @@ jobs:
             --repo "$REPO" \
             --prompt burlap \
             --aios-dir ../dotcms-aios \
-          | claude --print --allowedTools Bash,Write
+            > /tmp/eval_context.md
+
+          claude --print --allowedTools Bash,Write < /tmp/eval_context.md
 
       - name: Run finalize (apply + post comment + commit)
         working-directory: autodoc


### PR DESCRIPTION
The pipe from run_eval.py to Claude times out because run_eval.py is slow (GitHub API fetches). Write to a temp file first, then feed Claude via stdin redirect.