### PR TITLE
fix(autodoc): use AUTODOC_AIOS_CI for dotcms-aios checkout

### DIFF
--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -287,12 +287,3 @@ jobs:
               --data @/tmp/payload.json
           fi
 
-          # Commit the report back to dotcms-aios.
-          # Push only runs if commit succeeds (i.e. there were actual changes to commit).
-          cd dotcms-aios
-          git config user.name "autodoc[bot]"
-          git config user.email "autodoc-bot@users.noreply.github.com"
-          git add "autodoc/reports/Epic-${EPIC_NUMBER}_burlap.md"
-          if git commit -m "eval: Epic-${EPIC_NUMBER} (burlap)"; then
-            git push origin HEAD
-          fi

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotCMS/dotcms-aios
-          token: ${{ secrets.CI_MACHINE_TOKEN }}
+          token: ${{ secrets.AUTODOC_AIOS_CI }}
           path: dotcms-aios
 
       - name: Install Claude Code CLI


### PR DESCRIPTION
Replaces `CI_MACHINE_TOKEN` (which was never provisioned on this repo) with `AUTODOC_AIOS_CI`, the PAT that was previously working as `AUTODOC_TOKEN` and has now been re-provisioned under the new name.